### PR TITLE
set default log level to ERROR to suppress downstream usage output

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var HID = require('node-hid');
 var ByteBuffer = require('byte');
 var log = require('log4js').getLogger("speck-sensor");
 
+log.setLevel('ERROR');
+
 var SPECK_HID = {
    "vendorId" : 0x2354,
    "productId" : 0x3333


### PR DESCRIPTION
We are using this library in https://github.com/jywarren/opk-speck-cli, but to generate pipe-able JSON output for sending to data repositories, we need to suppress the debug output. It seems like in the library, debug output isn't necessary, and could cause trouble for some uses like ours. Hope this is an easy-to-read change!
